### PR TITLE
Support for Gnome 49

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -2,62 +2,57 @@
 
 'use strict';
 
-const { Gio, GLib } = imports.gi;
+import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
+import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-const Utils = Me.imports.utils;
+import Utils from './utils.js';
 
-let dayNigthWallpaperExtension;
-
-const DayNightWallpaperExtension = class DayNightWallpaperExtension {
-    constructor(settings) {
-        this._settings = settings;
+export default class DayNightWallpaperExtension extends Extension {
+    enable() {
+        this._settings = this.getSettings();
         this._scheduledTimeoutId = null;
         this._currentMode = null;
-    }
 
-    start() {
         this._connectSettings();
         this._refresh();
     }
 
-    stop() {
+    disable() {
         this._disconnectSettings();
 
         if (this._scheduledTimeoutId) {
-            GLib.source_remove(this._scheduledTimeoutId);
+            GLib.Source.remove(this._scheduledTimeoutId);
         }
         this._scheduledTimeoutId = null;
         this._currentMode = null;
+        this._settings = null;
     }
 
     _refresh() {
         const nextWallpaperSwitch = this._decideNextWallpaperSwitch();
-        const currentBackgroundUri = this._getDesktopBackgroundImage();
-        const currentBackgroundAdjustment = this._getDesktopBackgroundAdjustment();
-
+        
         if (nextWallpaperSwitch.mode == Utils.wallpaperMode.DAY) {
             this._currentMode = Utils.wallpaperMode.NIGHT;
             const nightWallpaperUri = this._settings.get_string('night-wallpaper');
             const nightWallpaperAdjustment = this._settings.get_string('night-wallpaper-adjustment');
-            if (currentBackgroundUri != nightWallpaperUri) {
-                this._setDesktopBackgroundImage(nightWallpaperUri);
-            }
-            if (currentBackgroundAdjustment != nightWallpaperAdjustment) {
-                this._setDesktopBackgroundAdjustment(nightWallpaperAdjustment);
-            }
+            
+            const bg = Utils.getDesktopBackgroundSettings();
+            bg.set_string('picture-uri', nightWallpaperUri);
+            bg.set_string('picture-uri-dark', nightWallpaperUri);
+            bg.set_string('picture-options', nightWallpaperAdjustment || 'zoom');
+            
             this._scheduleDayWallpaperSwitch(nextWallpaperSwitch.secondsLeftForSwitch);
         } else {
             this._currentMode = Utils.wallpaperMode.DAY;
             const dayWallpaperUri = this._settings.get_string('day-wallpaper');
             const dayWallpaperAdjustment = this._settings.get_string('day-wallpaper-adjustment');
-            if (currentBackgroundUri != dayWallpaperUri) {
-                this._setDesktopBackgroundImage(dayWallpaperUri);
-            }
-            if (currentBackgroundAdjustment != dayWallpaperAdjustment) {
-                this._setDesktopBackgroundAdjustment(dayWallpaperAdjustment);
-            }
+            
+            const bg = Utils.getDesktopBackgroundSettings();
+            bg.set_string('picture-uri', dayWallpaperUri);
+            bg.set_string('picture-uri-dark', dayWallpaperUri);
+            bg.set_string('picture-options', dayWallpaperAdjustment || 'zoom');
+            
             this._scheduleNightWallpaperSwitch(nextWallpaperSwitch.secondsLeftForSwitch);
         }
     }
@@ -66,18 +61,25 @@ const DayNightWallpaperExtension = class DayNightWallpaperExtension {
         log(`Setting desktop background => ${uri}, ${adjustment}`);
         const backgroundSettings = Utils.getDesktopBackgroundSettings();
         backgroundSettings.set_string('picture-uri', uri);
+        backgroundSettings.set_string('picture-uri-dark', uri);
         backgroundSettings.set_string('picture-options', adjustment);
     }
 
     _setDesktopBackgroundImage(uri) {
-        log(`Setting desktop background image => ${uri}`);
+        log(`_setDesktopBackgroundImage called with: ${uri}`);
         const backgroundSettings = Utils.getDesktopBackgroundSettings();
         backgroundSettings.set_string('picture-uri', uri);
+        backgroundSettings.set_string('picture-uri-dark', uri);
     }
 
     _getDesktopBackgroundImage() {
         const backgroundSettings = Utils.getDesktopBackgroundSettings();
         return backgroundSettings.get_string('picture-uri');
+    }
+
+    _getDesktopBackgroundImageDark() {
+        const backgroundSettings = Utils.getDesktopBackgroundSettings();
+        return backgroundSettings.get_string('picture-uri-dark');
     }
 
     _setDesktopBackgroundAdjustment(adjustment) {
@@ -99,14 +101,9 @@ const DayNightWallpaperExtension = class DayNightWallpaperExtension {
         const secondsLeftForDayWallpaperSwitch = this._calculateSecondsLeftForSwitch(dayWallpaperSwitchTime, now);
         const secondsLeftForNightWallpaperSwitch = this._calculateSecondsLeftForSwitch(nightWallpaperSwitchTime, now);
 
-        // Nearest switch time is scheduled first.
-        // If both Day & Night wallpaper switch times are same then
-        // day wallpaper is scheduled first.
         if (secondsLeftForDayWallpaperSwitch <= secondsLeftForNightWallpaperSwitch) {
-            // Schedule day wallpaper switch
             return new Utils.NextWallpaperSwitch(Utils.wallpaperMode.DAY, secondsLeftForDayWallpaperSwitch);
         } else {
-            // Schedule night wallpaper switch
             return new Utils.NextWallpaperSwitch(Utils.wallpaperMode.NIGHT, secondsLeftForNightWallpaperSwitch);
         }
     }
@@ -116,21 +113,6 @@ const DayNightWallpaperExtension = class DayNightWallpaperExtension {
         return switchDateTime.to_unix() - now.to_unix();
     }
 
-    /**
-     * Constructs GLib.DateTime object for the next switch with respect to the 
-     * current i.e. now DateTime instance.
-     * 
-     * If the current time has already crossed the passed switch time
-     * then the resultant DateTime will be of the next day.
-     * Example:- 
-     * Switch time => 09:00 Hrs
-     * Now => 19 Aug 2020 11:30 Hrs
-     * Result => 20 Aug 2020 09:00 Hrs
-     * 
-     * @param {Utils.SwitchTime} switchTime 
-     * @param {GLib.DateTime} now 
-     * @returns {GLib.DateTime} Switch DateTime object
-     */
     _constructSwitchDateTime(switchTime, now) {
         let timezone = GLib.TimeZone.new_local();
         let switchDateTime = GLib.DateTime.new(
@@ -143,30 +125,13 @@ const DayNightWallpaperExtension = class DayNightWallpaperExtension {
             0.0
         );
 
-        /**
-         * Adjust the day component for switch time.
-         * Example 1:- 
-         * Switch time => 09:00 Hrs
-         * Now => 19 Aug 2020 09:30 Hrs
-         * Result => 20 Aug 2020 09:00 Hrs
-         * 
-         * Example 2:-
-         * Switch time => 07:00 Hrs
-         * Now => 19 Aug 2020 09:30 Hrs
-         * Result => 20 Aug 2020 07:00 Hrs
-         * 
-         * Example 3:-
-         * Switch time => 09:00 Hrs
-         * Now => 19 Aug 2020 09:00 Hrs
-         * Result => 20 Aug 2020 09:00 Hrs
-         * */
         const nowHour = now.get_hour();
-        if (switchTime.switchHour == nowHour) { // Example 1 & 3
+        if (switchTime.switchHour == nowHour) {
             const nowMinute = now.get_minute();
             if (switchTime.switchMinute <= nowMinute) {
                 switchDateTime = switchDateTime.add_days(1);
             }
-        } else if (switchTime.switchHour < nowHour) { // Example 2
+        } else if (switchTime.switchHour < nowHour) {
             switchDateTime = switchDateTime.add_days(1);
         }
 
@@ -177,7 +142,12 @@ const DayNightWallpaperExtension = class DayNightWallpaperExtension {
         this._currentMode = Utils.wallpaperMode.DAY;
         const uri = this._settings.get_string('day-wallpaper');
         const adjustment = this._settings.get_string('day-wallpaper-adjustment');
-        this._setDesktopBackground(uri, adjustment);
+        
+        const bg = Utils.getDesktopBackgroundSettings();
+        bg.set_string('picture-uri', uri);
+        bg.set_string('picture-uri-dark', uri);
+        bg.set_string('picture-options', adjustment || 'zoom');
+        
         this._scheduleNightWallpaperSwitch();
         return GLib.SOURCE_REMOVE;
     }
@@ -186,7 +156,12 @@ const DayNightWallpaperExtension = class DayNightWallpaperExtension {
         this._currentMode = Utils.wallpaperMode.NIGHT;
         const uri = this._settings.get_string('night-wallpaper');
         const adjustment = this._settings.get_string('night-wallpaper-adjustment');
-        this._setDesktopBackground(uri, adjustment);
+        
+        const bg = Utils.getDesktopBackgroundSettings();
+        bg.set_string('picture-uri', uri);
+        bg.set_string('picture-uri-dark', uri);
+        bg.set_string('picture-options', adjustment || 'zoom');
+        
         this._scheduleDayWallpaperSwitch();
         return GLib.SOURCE_REMOVE;
     }
@@ -211,9 +186,9 @@ const DayNightWallpaperExtension = class DayNightWallpaperExtension {
         this._scheduledTimeoutId = GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, secondsLeftForNightWallpaperSwitch, this._onNightWallpaperTimeout.bind(this));
     }
 
-    _onWallpaperSwitchTimeChanged(settings, key) {
+    _onWallpaperSwitchTimeChanged() {
         if (this._scheduledTimeoutId) {
-            GLib.source_remove(this._scheduledTimeoutId);
+            GLib.Source.remove(this._scheduledTimeoutId);
         }
 
         this._scheduledTimeoutId = GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, 2, () => {
@@ -223,43 +198,29 @@ const DayNightWallpaperExtension = class DayNightWallpaperExtension {
     }
 
     _onDayWallpaperChanged() {
-        if (this._currentMode == Utils.wallpaperMode.DAY) {
-            const currentBackgroundUri = this._getDesktopBackgroundImage();
-            const dayWallpaperUri = this._settings.get_string('day-wallpaper');
-            if (currentBackgroundUri != dayWallpaperUri) {
-                this._setDesktopBackgroundImage(dayWallpaperUri);
-            }
-        }
+        const dayWallpaperUri = this._settings.get_string('day-wallpaper');
+        const bg = Utils.getDesktopBackgroundSettings();
+        bg.set_string('picture-uri', dayWallpaperUri);
+        bg.set_string('picture-uri-dark', dayWallpaperUri);
     }
 
     _onNightWallpaperChanged() {
-        if (this._currentMode == Utils.wallpaperMode.NIGHT) {
-            const currentBackgroundUri = this._getDesktopBackgroundImage();
-            const nightWallpaperUri = this._settings.get_string('night-wallpaper');
-            if (currentBackgroundUri != nightWallpaperUri) {
-                this._setDesktopBackgroundImage(nightWallpaperUri);
-            }
-        }
+        const nightWallpaperUri = this._settings.get_string('night-wallpaper');
+        const bg = Utils.getDesktopBackgroundSettings();
+        bg.set_string('picture-uri', nightWallpaperUri);
+        bg.set_string('picture-uri-dark', nightWallpaperUri);
     }
 
     _onDayWallpaperAdjustmentChanged() {
-        if (this._currentMode == Utils.wallpaperMode.DAY) {
-            const currentBackgroundAdjustment = this._getDesktopBackgroundAdjustment();
-            const dayWallpaperAdjustment = this._settings.get_string('day-wallpaper-adjustment');
-            if (currentBackgroundAdjustment != dayWallpaperAdjustment) {
-                this._setDesktopBackgroundAdjustment(dayWallpaperAdjustment);
-            }
-        }
+        const dayWallpaperAdjustment = this._settings.get_string('day-wallpaper-adjustment');
+        const bg = Utils.getDesktopBackgroundSettings();
+        bg.set_string('picture-options', dayWallpaperAdjustment || 'zoom');
     }
 
     _onNightWallpaperAdjustmentChanged() {
-        if (this._currentMode == Utils.wallpaperMode.NIGHT) {
-            const currentBackgroundAdjustment = this._getDesktopBackgroundAdjustment();
-            const nightWallpaperAdjustment = this._settings.get_string('night-wallpaper-adjustment');
-            if (currentBackgroundAdjustment != nightWallpaperAdjustment) {
-                this._setDesktopBackgroundAdjustment(nightWallpaperAdjustment);
-            }
-        }
+        const nightWallpaperAdjustment = this._settings.get_string('night-wallpaper-adjustment');
+        const bg = Utils.getDesktopBackgroundSettings();
+        bg.set_string('picture-options', nightWallpaperAdjustment || 'zoom');
     }
 
     _connectSettings() {
@@ -272,29 +233,29 @@ const DayNightWallpaperExtension = class DayNightWallpaperExtension {
     }
 
     _disconnectSettings() {
-        this._settings.disconnect(this._onDayWallpaperSwitchTimeChangedId);
-        this._settings.disconnect(this._onNightWallpaperSwitchTimeChangedId);
-        this._settings.disconnect(this._onDayWallpaperChangedId);
-        this._settings.disconnect(this._onNightWallpaperChangedId);
-        this._settings.disconnect(this._onDayWallpaperAdjustmentChangedId);
-        this._settings.disconnect(this._onNightWallpaperAdjustmentChangedId);
+        if (this._onDayWallpaperSwitchTimeChangedId) {
+            this._settings.disconnect(this._onDayWallpaperSwitchTimeChangedId);
+            this._onDayWallpaperSwitchTimeChangedId = null;
+        }
+        if (this._onNightWallpaperSwitchTimeChangedId) {
+            this._settings.disconnect(this._onNightWallpaperSwitchTimeChangedId);
+            this._onNightWallpaperSwitchTimeChangedId = null;
+        }
+        if (this._onDayWallpaperChangedId) {
+            this._settings.disconnect(this._onDayWallpaperChangedId);
+            this._onDayWallpaperChangedId = null;
+        }
+        if (this._onNightWallpaperChangedId) {
+            this._settings.disconnect(this._onNightWallpaperChangedId);
+            this._onNightWallpaperChangedId = null;
+        }
+        if (this._onDayWallpaperAdjustmentChangedId) {
+            this._settings.disconnect(this._onDayWallpaperAdjustmentChangedId);
+            this._onDayWallpaperAdjustmentChangedId = null;
+        }
+        if (this._onNightWallpaperAdjustmentChangedId) {
+            this._settings.disconnect(this._onNightWallpaperAdjustmentChangedId);
+            this._onNightWallpaperAdjustmentChangedId = null;
+        }
     }
-}
-
-function init() {
-    log(`Initializing ${Me.metadata.name}...`);
-    Utils.checkExtensionSettings();
-}
-
-function enable() {
-    log(`Enabling ${Me.metadata.name}...`);
-    const settings = ExtensionUtils.getSettings();
-    dayNigthWallpaperExtension = new DayNightWallpaperExtension(settings);
-    dayNigthWallpaperExtension.start();
-}
-
-function disable() {
-    log(`Disabling ${Me.metadata.name}...`);
-    dayNigthWallpaperExtension.stop();
-    dayNigthWallpaperExtension = null;
 }

--- a/metadata.json
+++ b/metadata.json
@@ -4,10 +4,11 @@
     "description": "Set separate wallpapers for day and night time.",
     "version": 2,
     "shell-version": [
-        "3.32",
-        "3.34",
-        "3.36",
-        "3.38"
+        "45",
+        "46",
+        "47",
+        "48",
+        "49"
     ],
     "settings-schema": "org.gnome.shell.extensions.day-night-wallpaper",
     "url": "https://github.com/swapnilmadavi/day-night-wallpaper-gnome-extension"

--- a/metadata.json
+++ b/metadata.json
@@ -4,10 +4,6 @@
     "description": "Set separate wallpapers for day and night time.",
     "version": 2,
     "shell-version": [
-        "45",
-        "46",
-        "47",
-        "48",
         "49"
     ],
     "settings-schema": "org.gnome.shell.extensions.day-night-wallpaper",

--- a/prefs.js
+++ b/prefs.js
@@ -21,6 +21,17 @@ export default class DayNightWallpaperPreferences extends ExtensionPreferences {
     fillPreferencesWindow(window) {
         const settings = getSettings();
         const pictureOptions = getAvailablePictureOptions().sort();
+        const defaultAdjustment = 'zoom';
+
+        const getAdjustmentIndex = adjustment => {
+            const preferred = adjustment || defaultAdjustment;
+            const preferredIndex = pictureOptions.indexOf(preferred);
+            if (preferredIndex >= 0)
+                return preferredIndex;
+
+            const defaultIndex = pictureOptions.indexOf(defaultAdjustment);
+            return defaultIndex >= 0 ? defaultIndex : 0;
+        };
 
         const imageFileFilter = new Gtk.FileFilter();
         imageFileFilter.set_name('Image files');
@@ -44,7 +55,8 @@ export default class DayNightWallpaperPreferences extends ExtensionPreferences {
         const dayAdjRow = new Adw.ActionRow({ title: 'Adjustment' });
         const dayAdjustmentCombo = new Gtk.ComboBoxText();
         pictureOptions.forEach(opt => dayAdjustmentCombo.append_text(opt.charAt(0).toUpperCase() + opt.slice(1)));
-        dayAdjustmentCombo.set_active(0);
+        const dayAdjustment = settings.get_string('day-wallpaper-adjustment');
+        dayAdjustmentCombo.set_active(getAdjustmentIndex(dayAdjustment));
         dayAdjRow.add_suffix(dayAdjustmentCombo);
         dayAdjRow.set_activatable_widget(dayAdjustmentCombo);
         dayGroup.add(dayAdjRow);
@@ -68,7 +80,8 @@ export default class DayNightWallpaperPreferences extends ExtensionPreferences {
         const nightAdjRow = new Adw.ActionRow({ title: 'Adjustment' });
         const nightAdjustmentCombo = new Gtk.ComboBoxText();
         pictureOptions.forEach(opt => nightAdjustmentCombo.append_text(opt.charAt(0).toUpperCase() + opt.slice(1)));
-        nightAdjustmentCombo.set_active(0);
+        const nightAdjustment = settings.get_string('night-wallpaper-adjustment');
+        nightAdjustmentCombo.set_active(getAdjustmentIndex(nightAdjustment));
         nightAdjRow.add_suffix(nightAdjustmentCombo);
         nightAdjRow.set_activatable_widget(nightAdjustmentCombo);
         nightGroup.add(nightAdjRow);
@@ -167,6 +180,38 @@ export default class DayNightWallpaperPreferences extends ExtensionPreferences {
                 dlg.destroy();
             });
             file.show();
+        });
+
+        dayAdjustmentCombo.connect('changed', () => {
+            const active = dayAdjustmentCombo.get_active();
+            if (active < 0 || active >= pictureOptions.length)
+                return;
+
+            const adjustment = pictureOptions[active];
+            settings.set_string('day-wallpaper-adjustment', adjustment);
+
+            const daySwitchTime = settings.get_double('day-wallpaper-switch-time');
+            const nightSwitchTime = settings.get_double('night-wallpaper-switch-time');
+            if (isDayNow(daySwitchTime, nightSwitchTime)) {
+                const bg = Gio.Settings.new('org.gnome.desktop.background');
+                bg.set_string('picture-options', adjustment);
+            }
+        });
+
+        nightAdjustmentCombo.connect('changed', () => {
+            const active = nightAdjustmentCombo.get_active();
+            if (active < 0 || active >= pictureOptions.length)
+                return;
+
+            const adjustment = pictureOptions[active];
+            settings.set_string('night-wallpaper-adjustment', adjustment);
+
+            const daySwitchTime = settings.get_double('day-wallpaper-switch-time');
+            const nightSwitchTime = settings.get_double('night-wallpaper-switch-time');
+            if (!isDayNow(daySwitchTime, nightSwitchTime)) {
+                const bg = Gio.Settings.new('org.gnome.desktop.background');
+                bg.set_string('picture-options', adjustment);
+            }
         });
 
         dayTimeWidget.hourSpinButton.connect('value-changed', () => {

--- a/prefs.js
+++ b/prefs.js
@@ -2,210 +2,199 @@
 
 'use strict';
 
-const { Gio, GObject, Gtk } = imports.gi;
+import Adw from 'gi://Adw';
+import GObject from 'gi://GObject';
+import Gtk from 'gi://Gtk';
+import Gio from 'gi://Gio';
+import { ExtensionPreferences } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-const SettingsUi = Me.imports.settingsUi;
-const Utils = Me.imports.utils;
+import SettingsUi from './settingsUi.js';
+import { SwitchTime, getAvailablePictureOptions, isDayNow } from './utils.js';
 
-let DayNightWallpaperPrefsWidget = GObject.registerClass(
-class DayNightWallpaperPrefsWidget extends Gtk.Grid {
-    _init(settings) {
-        super._init({
-            margin: 18,
-            column_spacing: 12,
-            row_spacing: 12,
-        })
+const SCHEMA_ID = 'org.gnome.shell.extensions.day-night-wallpaper';
 
-        // Day-Night Wallpaper settings
-        this._settings = settings;
-
-        // Image adjustment options
-        this._pictureOptions = Utils.getAvailablePictureOptions().sort();
-
-        // Image files filter
-        this._imageFileFilter = new Gtk.FileFilter();
-        this._imageFileFilter.set_name('Image files');
-        this._imageFileFilter.add_mime_type('image/jpg');
-        this._imageFileFilter.add_mime_type('image/png');
-        this._imageFileFilter.add_mime_type('image/jpeg');
-        this._imageFileFilter.add_mime_type('image/bmp');
-
-        this._dayWallpaperImageChooserButton = this._createWallpaperImageChooserButton(settings.get_string('day-wallpaper'));
-        this._dayWallpaperAdjustmentComboBoxText = this._createWallpaperAdjustmentComboBoxText(settings.get_string('day-wallpaper-adjustment'));
-        this._dayWallpaperSwitchTimeWidget = new SettingsUi.SwitchTimeWidget();
-        const _dayWallpaperSwitchTime = Utils.SwitchTime.newFromSettings(settings.get_double('day-wallpaper-switch-time'));
-        this._dayWallpaperSwitchTimeWidget.setSwitchTime(_dayWallpaperSwitchTime.switchHour, _dayWallpaperSwitchTime.switchMinute);
-
-        this._nightWallpaperImageChooserButton = this._createWallpaperImageChooserButton(settings.get_string('night-wallpaper'));
-        this._nightWallpaperAdjustmentComboBoxText = this._createWallpaperAdjustmentComboBoxText(settings.get_string('night-wallpaper-adjustment'));
-        this._nightWallpaperSwitchTimeWidget = new SettingsUi.SwitchTimeWidget();
-        const _nightWallpaperSwitchTime = Utils.SwitchTime.newFromSettings(settings.get_double('night-wallpaper-switch-time'));
-        this._nightWallpaperSwitchTimeWidget.setSwitchTime(_nightWallpaperSwitchTime.switchHour, _nightWallpaperSwitchTime.switchMinute);
-
-        this._buildDayWallpaperSection();
-        this._buildNightWallpaperSection();
-        this._buildAboutSection();
-
-        this._connectSettings();
-    }
-
-    _createWallpaperImageChooserButton(imageUri) {
-        let wallpaperImageChooserButton = new Gtk.FileChooserButton({
-            title: 'Image File',
-            action: Gtk.FileChooserAction.OPEN,
-            halign: Gtk.Align.END,
-            width_chars: 40,
-            filter: this._imageFileFilter
-        });
-        wallpaperImageChooserButton.set_uri(imageUri);
-        return wallpaperImageChooserButton;
-    }
-
-    _createWallpaperAdjustmentComboBoxText(adjustmentOption) {
-        let wallpaperAdjustmentComboBoxText = new Gtk.ComboBoxText();
-        let adjustmentOptionIndex = 0;
-        for (let i = 0; i < this._pictureOptions.length; i++) {
-            if (this._pictureOptions[i] == adjustmentOption) {
-                adjustmentOptionIndex = i;
-            }
-            wallpaperAdjustmentComboBoxText.append_text(this._capitalise(this._pictureOptions[i]));
-        }
-        wallpaperAdjustmentComboBoxText.set_active(adjustmentOptionIndex);
-        return wallpaperAdjustmentComboBoxText;
-    }
-
-    _buildDayWallpaperSection() {
-        // Day wallpaper title
-        const _dayWallpaperTitleLabel = new Gtk.Label({
-            label: `<b>Day Wallpaper</b>`,
-            halign: Gtk.Align.START,
-            use_markup: true
-        });
-        this.attach(_dayWallpaperTitleLabel, 0, 1, 2, 1);
-
-        // Day wallpaper image
-        const _dayWallpaperImageLabel = new Gtk.Label({
-            label: 'Image',
-            halign: Gtk.Align.START,
-            hexpand: true
-        });
-        this.attach(_dayWallpaperImageLabel, 0, 2, 1, 1);
-        this.attach_next_to(this._dayWallpaperImageChooserButton, _dayWallpaperImageLabel, Gtk.PositionType.RIGHT, 1, 1);
-
-        // Day wallpaper adjustment
-        const _dayWallpaperAdjustmentLabel = new Gtk.Label({
-            label: 'Adjustment',
-            halign: Gtk.Align.START,
-            hexpand: true
-        });
-        this.attach(_dayWallpaperAdjustmentLabel, 0, 3, 1, 1);
-        this.attach_next_to(this._dayWallpaperAdjustmentComboBoxText, _dayWallpaperAdjustmentLabel, Gtk.PositionType.RIGHT, 1, 1);
-
-        // Day wallpaper switch time
-        const _dayWallpaperSwitchTimeLabel = new Gtk.Label({
-            label: 'Switch Time (24-hour)',
-            halign: Gtk.Align.START,
-            hexpand: true
-        });
-        this.attach(_dayWallpaperSwitchTimeLabel, 0, 4, 1, 1);
-        this.attach_next_to(this._dayWallpaperSwitchTimeWidget, _dayWallpaperSwitchTimeLabel, Gtk.PositionType.RIGHT, 1, 1);
-    }
-
-    _buildNightWallpaperSection() {
-        // Night wallpaper title
-        const _nightWallpaperTitleLabel = new Gtk.Label({
-            label: `<b>Night Wallpaper</b>`,
-            halign: Gtk.Align.START,
-            use_markup: true,
-            margin_top: 18
-        });
-        this.attach(_nightWallpaperTitleLabel, 0, 5, 2, 1)
-
-        // Night wallpaper image
-        const _nightWallpaperImageLabel = new Gtk.Label({
-            label: 'Image',
-            halign: Gtk.Align.START,
-            hexpand: true
-        });
-        this.attach(_nightWallpaperImageLabel, 0, 6, 1, 1);
-        this.attach_next_to(this._nightWallpaperImageChooserButton, _nightWallpaperImageLabel, Gtk.PositionType.RIGHT, 1, 1);
-
-        // Night wallpaper adjustment
-        const _nightWallpaperAdjustmentLabel = new Gtk.Label({
-            label: 'Adjustment',
-            halign: Gtk.Align.START,
-            hexpand: true
-        });
-        this.attach(_nightWallpaperAdjustmentLabel, 0, 7, 1, 1);
-        this.attach_next_to(this._nightWallpaperAdjustmentComboBoxText, _nightWallpaperAdjustmentLabel, Gtk.PositionType.RIGHT, 1, 1);
-
-        // Night wallpaper switch time
-        const _nightWallpaperSwitchTimeLabel = new Gtk.Label({
-            label: 'Switch Time (24-hour)',
-            halign: Gtk.Align.START,
-            hexpand: true
-        });
-        this.attach(_nightWallpaperSwitchTimeLabel, 0, 8, 1, 1);
-        this.attach_next_to(this._nightWallpaperSwitchTimeWidget, _nightWallpaperSwitchTimeLabel, Gtk.PositionType.RIGHT, 1, 1);
-    }
-
-    _buildAboutSection() {
-        const _aboutSection = new SettingsUi.AboutSection();
-        _aboutSection.set_margin_top(18);
-        this.attach(_aboutSection, 0, 9, 2, 1);
-    }
-
-    _onDayWallpaperSwitchTimeChanged(spinButton) {
-        const daySwitchHour = this._dayWallpaperSwitchTimeWidget.hourSpinButton.get_value_as_int();
-        const daySwitchMinute = this._dayWallpaperSwitchTimeWidget.minuteSpinButton.get_value_as_int();
-        const daySwitchTime = new Utils.SwitchTime(daySwitchHour, daySwitchMinute);
-        this._settings.set_double('day-wallpaper-switch-time', daySwitchTime.toSettingsFormat());
-    }
-
-    _onNightWallpaperSwitchTimeChanged(spinButton) {
-        const nightSwitchHour = this._nightWallpaperSwitchTimeWidget.hourSpinButton.get_value_as_int();
-        const nightSwitchMinute = this._nightWallpaperSwitchTimeWidget.minuteSpinButton.get_value_as_int();
-        const nightSwitchTime = new Utils.SwitchTime(nightSwitchHour, nightSwitchMinute);
-        this._settings.set_double('night-wallpaper-switch-time', nightSwitchTime.toSettingsFormat());
-    }
-
-    _connectSettings() {
-        this._dayWallpaperImageChooserButton.connect('file-set', () => {
-            this._settings.set_string('day-wallpaper', this._dayWallpaperImageChooserButton.get_uri());
-        });
-        this._dayWallpaperAdjustmentComboBoxText.connect('changed', () => {
-            const activeItem = this._dayWallpaperAdjustmentComboBoxText.get_active();
-            this._settings.set_string('day-wallpaper-adjustment', this._pictureOptions[activeItem]);
-        });
-        this._dayWallpaperSwitchTimeWidget.hourSpinButton.connect('value-changed', this._onDayWallpaperSwitchTimeChanged.bind(this));
-        this._dayWallpaperSwitchTimeWidget.minuteSpinButton.connect('value-changed', this._onDayWallpaperSwitchTimeChanged.bind(this));
-
-        this._nightWallpaperImageChooserButton.connect('file-set', () => {
-            this._settings.set_string('night-wallpaper', this._nightWallpaperImageChooserButton.get_uri());
-        });
-        this._nightWallpaperAdjustmentComboBoxText.connect('changed', () => {
-            const activeItem = this._nightWallpaperAdjustmentComboBoxText.get_active();
-            this._settings.set_string('night-wallpaper-adjustment', this._pictureOptions[activeItem]);
-        });
-        this._nightWallpaperSwitchTimeWidget.hourSpinButton.connect('value-changed', this._onNightWallpaperSwitchTimeChanged.bind(this));
-        this._nightWallpaperSwitchTimeWidget.minuteSpinButton.connect('value-changed', this._onNightWallpaperSwitchTimeChanged.bind(this));
-    }
-
-    _capitalise(string) {
-        return string.charAt(0).toUpperCase() + string.slice(1)
-    }
-});
-
-function init() {
-    Utils.checkExtensionSettings();
+function getSettings() {
+    return Gio.Settings.new(SCHEMA_ID);
 }
 
-function buildPrefsWidget() {
-    const settings = ExtensionUtils.getSettings();
-    const prefsWidget = new DayNightWallpaperPrefsWidget(settings);
-    prefsWidget.show_all();
+export default class DayNightWallpaperPreferences extends ExtensionPreferences {
+    fillPreferencesWindow(window) {
+        const settings = getSettings();
+        const pictureOptions = getAvailablePictureOptions().sort();
 
-    return prefsWidget;
+        const imageFileFilter = new Gtk.FileFilter();
+        imageFileFilter.set_name('Image files');
+        imageFileFilter.add_mime_type('image/jpg');
+        imageFileFilter.add_mime_type('image/png');
+        imageFileFilter.add_mime_type('image/jpeg');
+        imageFileFilter.add_mime_type('image/bmp');
+
+        const page = new Adw.PreferencesPage();
+        
+        const dayGroup = new Adw.PreferencesGroup();
+        dayGroup.set_title('Day Wallpaper');
+        page.add(dayGroup);
+
+        const dayImageRow = new Adw.ActionRow({ title: 'Image' });
+        const dayImageButton = new Gtk.Button({ label: 'Choose...' });
+        dayImageRow.add_suffix(dayImageButton);
+        dayImageRow.set_activatable_widget(dayImageButton);
+        dayGroup.add(dayImageRow);
+
+        const dayAdjRow = new Adw.ActionRow({ title: 'Adjustment' });
+        const dayAdjustmentCombo = new Gtk.ComboBoxText();
+        pictureOptions.forEach(opt => dayAdjustmentCombo.append_text(opt.charAt(0).toUpperCase() + opt.slice(1)));
+        dayAdjustmentCombo.set_active(0);
+        dayAdjRow.add_suffix(dayAdjustmentCombo);
+        dayAdjRow.set_activatable_widget(dayAdjustmentCombo);
+        dayGroup.add(dayAdjRow);
+
+        const dayTimeRow = new Adw.ActionRow({ title: 'Switch Time (24h)' });
+        const dayTimeWidget = new SettingsUi.SwitchTimeWidget();
+        dayTimeRow.add_suffix(dayTimeWidget);
+        dayTimeRow.set_activatable_widget(dayTimeWidget.hourSpinButton);
+        dayGroup.add(dayTimeRow);
+
+        const nightGroup = new Adw.PreferencesGroup();
+        nightGroup.set_title('Night Wallpaper');
+        page.add(nightGroup);
+
+        const nightImageRow = new Adw.ActionRow({ title: 'Image' });
+        const nightImageButton = new Gtk.Button({ label: 'Choose...' });
+        nightImageRow.add_suffix(nightImageButton);
+        nightImageRow.set_activatable_widget(nightImageButton);
+        nightGroup.add(nightImageRow);
+
+        const nightAdjRow = new Adw.ActionRow({ title: 'Adjustment' });
+        const nightAdjustmentCombo = new Gtk.ComboBoxText();
+        pictureOptions.forEach(opt => nightAdjustmentCombo.append_text(opt.charAt(0).toUpperCase() + opt.slice(1)));
+        nightAdjustmentCombo.set_active(0);
+        nightAdjRow.add_suffix(nightAdjustmentCombo);
+        nightAdjRow.set_activatable_widget(nightAdjustmentCombo);
+        nightGroup.add(nightAdjRow);
+
+        const nightTimeRow = new Adw.ActionRow({ title: 'Switch Time (24h)' });
+        const nightTimeWidget = new SettingsUi.SwitchTimeWidget();
+        nightTimeRow.add_suffix(nightTimeWidget);
+        nightTimeRow.set_activatable_widget(nightTimeWidget.hourSpinButton);
+        nightGroup.add(nightTimeRow);
+
+        window.add(page);
+
+        const daySwitchTime = SwitchTime.newFromSettings(settings.get_double('day-wallpaper-switch-time'));
+        dayTimeWidget.setSwitchTime(daySwitchTime.switchHour, daySwitchTime.switchMinute);
+
+        const nightSwitchTime = SwitchTime.newFromSettings(settings.get_double('night-wallpaper-switch-time'));
+        nightTimeWidget.setSwitchTime(nightSwitchTime.switchHour, nightSwitchTime.switchMinute);
+
+        const currentDayWallpaper = settings.get_string('day-wallpaper');
+        if (currentDayWallpaper) {
+            try {
+                const file = Gio.File.new_for_uri(currentDayWallpaper);
+                dayImageButton.set_label(file.get_basename().substring(0, 20) || 'Choose...');
+            } catch (e) {}
+        }
+
+        const currentNightWallpaper = settings.get_string('night-wallpaper');
+        if (currentNightWallpaper) {
+            try {
+                const file = Gio.File.new_for_uri(currentNightWallpaper);
+                nightImageButton.set_label(file.get_basename().substring(0, 20) || 'Choose...');
+            } catch (e) {}
+        }
+
+        dayImageButton.connect('clicked', () => {
+            const file = Gtk.FileChooserNative.new(
+                'Select Day Wallpaper',
+                null,
+                Gtk.FileChooserAction.OPEN,
+                '_Open',
+                '_Cancel'
+            );
+            
+            file.connect('response', (dlg, response) => {
+                if (response === Gtk.ResponseType.ACCEPT) {
+                    const selectedFile = dlg.get_file();
+                    if (selectedFile) {
+                        const uri = selectedFile.get_uri();
+                        settings.set_string('day-wallpaper', uri);
+                        dayImageButton.set_label(selectedFile.get_basename().substring(0, 20));
+                        
+                        const daySwitchTime = settings.get_double('day-wallpaper-switch-time');
+                        const nightSwitchTime = settings.get_double('night-wallpaper-switch-time');
+                        const isCurrentlyDay = isDayNow(daySwitchTime, nightSwitchTime);
+                        
+                        if (isCurrentlyDay) {
+                            const bg = Gio.Settings.new('org.gnome.desktop.background');
+                            bg.set_string('picture-uri', uri);
+                            bg.set_string('picture-uri-dark', uri);
+                        }
+                    }
+                }
+                dlg.destroy();
+            });
+            file.show();
+        });
+
+        nightImageButton.connect('clicked', () => {
+            const file = Gtk.FileChooserNative.new(
+                'Select Night Wallpaper',
+                null,
+                Gtk.FileChooserAction.OPEN,
+                '_Open',
+                '_Cancel'
+            );
+            
+            file.connect('response', (dlg, response) => {
+                if (response === Gtk.ResponseType.ACCEPT) {
+                    const selectedFile = dlg.get_file();
+                    if (selectedFile) {
+                        const uri = selectedFile.get_uri();
+                        settings.set_string('night-wallpaper', uri);
+                        nightImageButton.set_label(selectedFile.get_basename().substring(0, 20));
+                        
+                        const daySwitchTime = settings.get_double('day-wallpaper-switch-time');
+                        const nightSwitchTime = settings.get_double('night-wallpaper-switch-time');
+                        const isCurrentlyDay = isDayNow(daySwitchTime, nightSwitchTime);
+                        
+                        if (!isCurrentlyDay) {
+                            const bg = Gio.Settings.new('org.gnome.desktop.background');
+                            bg.set_string('picture-uri', uri);
+                            bg.set_string('picture-uri-dark', uri);
+                        }
+                    }
+                }
+                dlg.destroy();
+            });
+            file.show();
+        });
+
+        dayTimeWidget.hourSpinButton.connect('value-changed', () => {
+            const hour = dayTimeWidget.hourSpinButton.get_value_as_int();
+            const minute = dayTimeWidget.minuteSpinButton.get_value_as_int();
+            const time = new SwitchTime(hour, minute);
+            settings.set_double('day-wallpaper-switch-time', time.toSettingsFormat());
+        });
+
+        dayTimeWidget.minuteSpinButton.connect('value-changed', () => {
+            const hour = dayTimeWidget.hourSpinButton.get_value_as_int();
+            const minute = dayTimeWidget.minuteSpinButton.get_value_as_int();
+            const time = new SwitchTime(hour, minute);
+            settings.set_double('day-wallpaper-switch-time', time.toSettingsFormat());
+        });
+
+        nightTimeWidget.hourSpinButton.connect('value-changed', () => {
+            const hour = nightTimeWidget.hourSpinButton.get_value_as_int();
+            const minute = nightTimeWidget.minuteSpinButton.get_value_as_int();
+            const time = new SwitchTime(hour, minute);
+            settings.set_double('night-wallpaper-switch-time', time.toSettingsFormat());
+        });
+
+        nightTimeWidget.minuteSpinButton.connect('value-changed', () => {
+            const hour = nightTimeWidget.hourSpinButton.get_value_as_int();
+            const minute = nightTimeWidget.minuteSpinButton.get_value_as_int();
+            const time = new SwitchTime(hour, minute);
+            settings.set_double('night-wallpaper-switch-time', time.toSettingsFormat());
+        });
+    }
 }

--- a/settingsUi.js
+++ b/settingsUi.js
@@ -2,14 +2,16 @@
 
 'use strict';
 
-const { GObject, Gtk } = imports.gi;
+import GObject from 'gi://GObject';
+import Gtk from 'gi://Gtk';
 
 var SwitchTimeWidget = GObject.registerClass(
 class SwitchTimeWidget extends Gtk.Box {
     _init() {
         super._init({
             spacing: 4,
-            halign: Gtk.Align.CENTER
+            halign: Gtk.Align.CENTER,
+            orientation: Gtk.Orientation.HORIZONTAL
         })
 
         const _hourSpinAdustment = new Gtk.Adjustment({
@@ -22,7 +24,7 @@ class SwitchTimeWidget extends Gtk.Box {
             upper: 59,
             step_increment: 1
         });
-        const _timeColonLabel = Gtk.Label.new(':');
+        const _timeColonLabel = Gtk.Label.new(' : ');
 
         this.hourSpinButton = new Gtk.SpinButton({
             adjustment: _hourSpinAdustment,
@@ -30,8 +32,7 @@ class SwitchTimeWidget extends Gtk.Box {
             width_chars: 2,
             max_width_chars: 2,
             snap_to_ticks: true,
-            numeric: true,
-            orientation: Gtk.Orientation.VERTICAL
+            numeric: true
         });
 
         this.minuteSpinButton = new Gtk.SpinButton({
@@ -40,16 +41,15 @@ class SwitchTimeWidget extends Gtk.Box {
             width_chars: 2,
             max_width_chars: 2,
             snap_to_ticks: true,
-            numeric: true,
-            orientation: Gtk.Orientation.VERTICAL
+            numeric: true
         });
 
         this.hourSpinButton.connect('output', this._padValueWithLeadingZero.bind(this));
         this.minuteSpinButton.connect('output', this._padValueWithLeadingZero.bind(this));
 
-        this.pack_start(this.hourSpinButton, false, false, 0);
-        this.pack_start(_timeColonLabel, false, false, 0);
-        this.pack_start(this.minuteSpinButton, false, false, 0);
+        this.append(this.hourSpinButton);
+        this.append(_timeColonLabel);
+        this.append(this.minuteSpinButton);
     }
 
     setSwitchTime(switchHour, switchMinute) {
@@ -72,7 +72,8 @@ class AboutSection extends Gtk.Box {
         super._init({
             orientation: Gtk.Orientation.VERTICAL,
             spacing: 6,
-            halign: Gtk.Align.CENTER
+            halign: Gtk.Align.CENTER,
+            margin_top: 18
         })
 
         const createdByLabel = new Gtk.Label({
@@ -87,7 +88,12 @@ class AboutSection extends Gtk.Box {
             use_markup: true
         });
 
-        this.pack_start(createdByLabel, false, true, 0);
-        this.pack_start(homepageLabel, false, true, 0);
+        this.append(createdByLabel);
+        this.append(homepageLabel);
     }
 });
+
+export default {
+    SwitchTimeWidget,
+    AboutSection
+};

--- a/utils.js
+++ b/utils.js
@@ -2,40 +2,52 @@
 
 'use strict';
 
-const ExtensionUtils = imports.misc.extensionUtils;
+import Gio from 'gi://Gio';
 
-var wallpaperMode = {
+export const wallpaperMode = {
     DAY: 1,
     NIGHT: 2
 };
 
-function getDesktopBackgroundSettings() {
-    return ExtensionUtils.getSettings('org.gnome.desktop.background');
+export function getDesktopBackgroundSettings() {
+    return Gio.Settings.new('org.gnome.desktop.background');
 }
 
-function getAvailablePictureOptions() {
+export function getAvailablePictureOptions() {
     const backgroundSettings = getDesktopBackgroundSettings();
-    return backgroundSettings.settings_schema.get_key('picture-options').get_range().get_child_value(1).get_child_value(0).deep_unpack();
+    const schema = backgroundSettings.settings_schema;
+    const key = schema.get_key('picture-options');
+    return key.get_range().get_child_value(1).get_child_value(0).deep_unpack();
 }
 
-function isWallpaperOptionSelected(extensionSettings, wallpaperKey) {
+export function isWallpaperOptionSelected(extensionSettings, wallpaperKey) {
     return extensionSettings.get_string(wallpaperKey) != '';
 }
 
-function fallbackToSystemWallpaper(extensionSettings, wallpaperKey) {
+export function fallbackToSystemWallpaper(extensionSettings, wallpaperKey) {
     const backgroundSettings = getDesktopBackgroundSettings();
     const systemBackgroundUri = backgroundSettings.get_string('picture-uri');
     extensionSettings.set_string(wallpaperKey, systemBackgroundUri);
 }
 
-function fallbackToSystemWallpaperAdjustment(extensionSettings, wallpaperAdjustmentKey) {
+export function fallbackToSystemWallpaperAdjustment(extensionSettings, wallpaperAdjustmentKey) {
     const backgroundSettings = getDesktopBackgroundSettings();
     const systemBackgroundAdjustment = backgroundSettings.get_string('picture-options');
     extensionSettings.set_string(wallpaperAdjustmentKey, systemBackgroundAdjustment);
 }
 
-function checkExtensionSettings() {
-    const extensionSettings = ExtensionUtils.getSettings();
+const SCHEMA_ID = 'org.gnome.shell.extensions.day-night-wallpaper';
+
+function getExtensionSettings() {
+    return Gio.Settings.new(SCHEMA_ID);
+}
+
+export function checkExtensionSettings() {
+    const extensionSettings = getExtensionSettings();
+    if (!extensionSettings) {
+        log('Could not get extension settings');
+        return;
+    }
 
     if (!isWallpaperOptionSelected(extensionSettings, 'day-wallpaper')) {
         fallbackToSystemWallpaper(extensionSettings, 'day-wallpaper');
@@ -54,7 +66,7 @@ function checkExtensionSettings() {
     }
 }
 
-var SwitchTime = class SwitchTime {
+export class SwitchTime {
     constructor(switchHour, switchMinute) {
         this._switchHour = switchHour;
         this._switchMinute = switchMinute;
@@ -83,7 +95,7 @@ var SwitchTime = class SwitchTime {
     }
 }
 
-var NextWallpaperSwitch = class NextWallpaperSwitch {
+export class NextWallpaperSwitch {
     constructor(mode, secondsLeftForSwitch) {
         this._mode = mode;
         this._secondsLeftForSwitch = secondsLeftForSwitch;
@@ -97,3 +109,32 @@ var NextWallpaperSwitch = class NextWallpaperSwitch {
         return this._secondsLeftForSwitch;
     }
 }
+
+export function isDayNow(daySwitchTime, nightSwitchTime) {
+    const now = new Date();
+    const currentHour = now.getHours();
+    const currentMinute = now.getMinutes();
+    const currentTimeMinutes = currentHour * 60 + currentMinute;
+    
+    const dayTimeMinutes = Math.floor(daySwitchTime) * 60 + Math.round((daySwitchTime % 1) * 60);
+    const nightTimeMinutes = Math.floor(nightSwitchTime) * 60 + Math.round((nightSwitchTime % 1) * 60);
+    
+    if (dayTimeMinutes < nightTimeMinutes) {
+        return currentTimeMinutes >= dayTimeMinutes && currentTimeMinutes < nightTimeMinutes;
+    } else {
+        return currentTimeMinutes >= dayTimeMinutes || currentTimeMinutes < nightTimeMinutes;
+    }
+}
+
+export default {
+    wallpaperMode,
+    getDesktopBackgroundSettings,
+    getAvailablePictureOptions,
+    isWallpaperOptionSelected,
+    fallbackToSystemWallpaper,
+    fallbackToSystemWallpaperAdjustment,
+    checkExtensionSettings,
+    SwitchTime,
+    NextWallpaperSwitch,
+    isDayNow
+};


### PR DESCRIPTION
Hey i wanted this for my desktop which has gnome 49 (wayland) so i tried to fork it and update the code to make it work.

These are the things i changed

- changed the extension.js to support es module imports.
- Removed deprecated functions and replaced them with newer ones
- changed the wallpaper change mechanism by also changing picture-uri
- implemented a feature to auto apply wallpaper if preview is changed for the current day night period
- adding Awd ui elements instead of gtk.grid

this is how it looks and works right now


https://github.com/user-attachments/assets/831d2ef4-e1ca-466a-942b-e30b8bd668f8

would love feedback from you to change stuff and i wired the image adjustment but not sure how it was supposed to work . it needs durther testing